### PR TITLE
A solution for secrets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,9 @@ RUN bash -c "\
     mkdir -p /skyportal/static/thumbnails && \
     chown -R skyportal.skyportal /skyportal/static/thumbnails && \
     \
-    cp docker.yaml config.yaml"
+    cp docker.yaml config.yaml && \
+    \
+    chmod +x docker-entrypoint.sh"
 
 USER skyportal
 
@@ -52,3 +54,5 @@ EXPOSE 5000
 CMD bash -c "source /skyportal_env/bin/activate && \
              (make log &) && \
              make run_production"
+
+ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,19 +3,33 @@ version: "3.7"
 services:
   web:
     image: skyportal/web
+    environment:
+      SKYPORTAL_DATABASE_USER_FILE: /run/secrets/skyportal-database-user
+      SKYPORTAL_DATABASE_PASSWORD_FILE: /run/secrets/skyportal-database-password
     ports:
       - "9000:5000"
       - "9001:5001"
+    secrets:
+      - skyportal-database-user
+      - skyportal-database-password
     volumes:
       - thumbnails:/skyportal/static/thumbnails
 
   db:
     image: postgres:12.2
     environment:
-      POSTGRES_USER: skyportal
-      POSTGRES_PASSWORD: password
+      POSTGRES_USER_FILE: /run/secrets/skyportal-database-user
+      POSTGRES_PASSWORD_FILE: /run/secrets/skyportal-database-password
       POSTGRES_DB: skyportal
       PGDATA: /var/lib/postgresql/data/pgdata
+#   environment:
+#     POSTGRES_USER: skyportal
+#     POSTGRES_PASSWORD: password
+#     POSTGRES_DB: skyportal
+#     PGDATA: /var/lib/postgresql/data/pgdata
+    secrets:
+      - skyportal-database-user
+      - skyportal-database-password
     volumes:
       - dbdata:/var/lib/postgresql/data/pgdata
     restart: on-failure:3
@@ -23,3 +37,9 @@ services:
 volumes:
   dbdata:
   thumbnails:
+
+secrets:
+  skyportal-database-user:
+    file: ./secrets/skyportal-database-user.txt
+  skyportal-database-password:
+    file: ./secrets/skyportal-database-password.txt

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+file_env() {
+    local var="$1"
+    local fileVar="${var}_FILE"
+    local def="${2:-}"
+    if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+        echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+        exit 1
+    fi
+    local val="$def"
+    if [ "${!var:-}" ]; then
+        val="${!var}"
+    elif [ "${!fileVar:-}" ]; then
+        val="$(< "${!fileVar}")"
+    fi
+    export "$var"="$val"
+    unset "$fileVar"
+}
+
+file_env 'SKYPORTAL_DATABASE_USER'
+file_env 'SKYPORTAL_DATABASE_PASSWORD'
+
+sed -i "s/SKYPORTAL_DATABASE_USER/$SKYPORTAL_DATABASE_USER/" config.yaml
+sed -i "s/SKYPORTAL_DATABASE_PASSWORD/$SKYPORTAL_DATABASE_PASSWORD/" config.yaml
+
+exec "$@"

--- a/docker.yaml
+++ b/docker.yaml
@@ -2,8 +2,8 @@ database:
     database: skyportal
     host: db
     port: 5432
-    user: skyportal
-    password: password
+    user: SKYPORTAL_DATABASE_USER
+    password: SKYPORTAL_DATABASE_PASSWORD
 
 server:
     url: http://localhost:5000

--- a/secrets/skyportal-database-password.txt
+++ b/secrets/skyportal-database-password.txt
@@ -1,0 +1,1 @@
+password

--- a/secrets/skyportal-database-user.txt
+++ b/secrets/skyportal-database-user.txt
@@ -1,0 +1,1 @@
+skyportal


### PR DESCRIPTION
Looks like there are conflicts because you have changes that aren't in the upstream, but I still think it's easy to see the point of what I'm doing here.  I'm not suggesting you necessarily merge because you might find another solution.

What we do is use a very standard solution for handling secrets in container-based environments.  In fact since SkyPortal is using PostgreSQL this solution just works out of the box for it and requires no changes to the PostgreSQL container whatsoever.  We just steal the same `file_env()` and use it here.

The idea is that the database credentials are stored as secrets.  This works fine in docker-compose 3 so you can test it out on your local system probably.  These images should work with secrets in Rancher 2 depending on how you set those up when you deploy the workload.

The sed to replace the values in the config file is cheesy but gets the point across.  You might want to manage that config in a more sophisticated way (like template it, or manage it with some python script that fills in the blanks).